### PR TITLE
Reduce Queries in Email Summary View

### DIFF
--- a/logistics/views.py
+++ b/logistics/views.py
@@ -550,8 +550,12 @@ def summary(request, context=None):
         counts = {}
         total = 0
         for key in ('stockout_count', 'emergency_plus_low', 'good_supply_count', 'overstocked_count'):
-            count = getattr(location, key)(
-                product=product.code, datespan=datespan
+            count = location._get_stock_count_for_facilities(
+                facilities=facilities,
+                operation='%s_count' % key,
+                product=product.code,
+                producttype=None,
+                datespan=datespan
             )
             counts[key] = count
             total = total + (count or 0)


### PR DESCRIPTION
The summary view was calling `location.stockout_count` etc which was in turn calling `_get_stock_count` which called `_get_stock_count_for_facilities` while running a query for all the child facilities. Since we already have the set of facilities this significantly reduces the number of queries inside the loop by passing this list directly to `_get_stock_count_for_facilities`.
